### PR TITLE
Update env.yaml

### DIFF
--- a/c3/env.yaml
+++ b/c3/env.yaml
@@ -4,7 +4,9 @@ channels:
   - defaults
 dependencies:
   - python=3.6
+  - dill=0.3.3
   - tensorflow=2.1.0
+  - tensorflow-estimator=2.1.0
   - pandas=0.25.2
   - python-dateutil
   - h5py=2.9.0


### PR DESCRIPTION
This fixes the following issue when importing tensorflow using a kernel defined with this env.yaml:

AttributeError: module 'tensorflow' has no attribute 'compat'
Notes:
-- maybe include explicit tensorflow-estimator=2.1.0??
Have this from conda list -n mnist:
```tensorflow                2.1.0           mkl_py36h23468d9_0    defaults
tensorflow-base           2.1.0           mkl_py36h6d63fb7_0    defaults
tensorflow-estimator      2.2.0              pyh95af2a2_0    conda-forge
```
explicitly adding the conda-estimator version fixes the import
